### PR TITLE
Allow "Advanced Game Options" to show up for ports. 

### DIFF
--- a/es-app/src/guis/GuiGameOptions.cpp
+++ b/es-app/src/guis/GuiGameOptions.cpp
@@ -385,15 +385,12 @@ GuiGameOptions::GuiGameOptions(Window* window, FileData* game) : GuiComponent(wi
 
 			if (game->getType() != FOLDER)
 			{
-				if (srcSystem->hasFeatures() || srcSystem->hasEmulatorSelection())
-				{
 					mHasAdvancedGameOptions = true;
 					mMenu.addEntry(_("ADVANCED GAME OPTIONS"), false, [this, game]
 					{
 						GuiMenu::popGameConfigurationGui(mWindow, game);
 						close();
 					});
-				}
 			}
 		}
 


### PR DESCRIPTION
This will allow advanced game options to show up for ports. 

Will also allow it to show for tools, so will need to look into how to turn it off but tools also has other options as well. 

Tested on latest dev branch. 