### PR TITLE
Add WireGuard VPN menu item into Network Settings

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4180,6 +4180,20 @@ void GuiMenu::openNetworkSettings_batocera(bool selectWifiEnable)
                                 SystemConf::getInstance()->saveSystemConf();
                 });
 
+        auto wireguard = std::make_shared<SwitchComponent>(mWindow);
+			  bool wgUp = SystemConf::getInstance()->get("wireguard.up") == "1";
+        wireguard->setState(wgUp);
+        s->addWithLabel(_("WIREGUARD VPN"), wireguard);
+        s->addSaveFunc([wireguard] {
+					if (wireguard->getState() == false) {
+						runSystemCommand("/bin/bash wg-quick down /storage/roms/wireguard/wg0.conf", "", nullptr);
+					} else {
+						runSystemCommand("/bin/bash wg-quick up /storage/roms/wireguard/wg0.conf", "", nullptr);
+					}
+					SystemConf::getInstance()->set("wireguard.up", wireguard->getState() ? "1" : "0");
+					SystemConf::getInstance()->saveSystemConf();
+        });
+								
 	mWindow->pushGui(s);
 }
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4180,19 +4180,22 @@ void GuiMenu::openNetworkSettings_batocera(bool selectWifiEnable)
                                 SystemConf::getInstance()->saveSystemConf();
                 });
 
-        auto wireguard = std::make_shared<SwitchComponent>(mWindow);
-			  bool wgUp = SystemConf::getInstance()->get("wireguard.up") == "1";
-        wireguard->setState(wgUp);
-        s->addWithLabel(_("WIREGUARD VPN"), wireguard);
-        s->addSaveFunc([wireguard] {
-					if (wireguard->getState() == false) {
-						runSystemCommand("/bin/bash wg-quick down /storage/roms/wireguard/wg0.conf", "", nullptr);
-					} else {
-						runSystemCommand("/bin/bash wg-quick up /storage/roms/wireguard/wg0.conf", "", nullptr);
-					}
-					SystemConf::getInstance()->set("wireguard.up", wireguard->getState() ? "1" : "0");
-					SystemConf::getInstance()->saveSystemConf();
-        });
+	const std::string wireguardConfigFile = "/storage/roms/wireguard/wg0.conf";
+	if (Utils::FileSystem::exists(wireguardConfigFile)) {
+		auto wireguard = std::make_shared<SwitchComponent>(mWindow);
+		bool wgUp = SystemConf::getInstance()->get("wireguard.up") == "1";
+		wireguard->setState(wgUp);
+		s->addWithLabel(_("WIREGUARD VPN"), wireguard);
+		s->addSaveFunc([wireguard, wireguardConfigFile] {
+			if (wireguard->getState() == false) {
+				runSystemCommand("wg-quick down " + wireguardConfigFile, "", nullptr);
+			} else {
+				runSystemCommand("wg-quick up " + wireguardConfigFile, "", nullptr);
+			}
+			SystemConf::getInstance()->set("wireguard.up", wireguard->getState() ? "1" : "0");
+			SystemConf::getInstance()->saveSystemConf();
+		});
+	}
 								
 	mWindow->pushGui(s);
 }

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4180,7 +4180,7 @@ void GuiMenu::openNetworkSettings_batocera(bool selectWifiEnable)
                                 SystemConf::getInstance()->saveSystemConf();
                 });
 
-	const std::string wireguardConfigFile = "/storage/roms/wireguard/wg0.conf";
+	const std::string wireguardConfigFile = "/storage/.config/wireguard/wg0.conf";
 	if (Utils::FileSystem::exists(wireguardConfigFile)) {
 		auto wireguard = std::make_shared<SwitchComponent>(mWindow);
 		bool wgUp = SystemConf::getInstance()->get("wireguard.up") == "1";


### PR DESCRIPTION
# Add WireGuard VPN menu item into Network Settings

## Description

This adds an extra menu item (WIREGUARD VPN) into Network Settings menu.
The item is a toggle which turns on or off VPN connection.
The item is only visible if WireGuard config file exists in the known location ("/storage/.config/wireguard/wg0.conf").

Note: a separate PR is needed to bring back up VPN connection on OS startup.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested Locally?

emulationstation binary was built using custom built from source code. I will submit a separate PR with instructions.
emulationstation was placed localy into the device and run.

- [x] Test A: Config file is missing. No menu item.
- [x] Test B: Config file is present. Menu item appears.
1. In a separate terminal run "wg show", no active connections.
2. Toggle WIRGUARD VPN on. Exit Network settings dialog.
3. "wg show" shows an active connection.
4. Toggle WIRGUARD VPN off. Exit Network settings dialog.
5. "wg show" shows no connection.

**Test Configuration**: RG351V
* Build OS name and version: custom dev build
* Docker (Y/N): N
* JELOS Branch: dev
* Any additional information that may be useful:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
