### PR TITLE
Add Moonlight Game Streaming menu

### DIFF
--- a/es-app/CMakeLists.txt
+++ b/es-app/CMakeLists.txt
@@ -71,6 +71,7 @@ set(ES_HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiGameAchievements.h		
 	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiSaveState.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiFileBrowser.h	
+	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiMoonlight.h	
 	
     # Scrapers
     ${CMAKE_CURRENT_SOURCE_DIR}/src/scrapers/Scraper.h
@@ -168,6 +169,7 @@ set(ES_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiGameAchievements.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiSaveState.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiFileBrowser.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiMoonlight.cpp
 
     # Scrapers
     ${CMAKE_CURRENT_SOURCE_DIR}/src/scrapers/Scraper.cpp

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -18,6 +18,7 @@
 #include "guis/GuiRetroAchievements.h" //batocera
 #include "guis/GuiGamelistOptions.h"
 #include "guis/GuiImageViewer.h"
+#include "guis/GuiMoonlight.h"
 #include "views/UIModeController.h"
 #include "views/ViewController.h"
 #include "CollectionSystemManager.h"
@@ -150,8 +151,10 @@ GuiMenu::GuiMenu(Window *window, bool animate) : GuiComponent(window), mMenu(win
 		//addEntry(_("CONTROLLERS SETTINGS").c_str(), true, [this] { openControllersSettings_batocera(); }, "iconControllers");
 		addEntry(_("SOUND SETTINGS").c_str(), true, [this] { openSoundSettings(); }, "iconSound");
 
-		if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::WIFI))
+		if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::WIFI)) {
 			addEntry(_("NETWORK SETTINGS").c_str(), true, [this] { openNetworkSettings_batocera(); }, "iconNetwork");
+		  addEntry(_("MOONLIGHT GAME STREAMING").c_str(), true, [this] { GuiMoonlight::show(mWindow); }, "iconGames");
+		}
 #else
 		if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::GAMESETTINGS))
 			addEntry(_("GAME SETTINGS").c_str(), true, [this] { openGamesSettings_batocera(); }, "iconGames");

--- a/es-app/src/guis/GuiMoonlight.cpp
+++ b/es-app/src/guis/GuiMoonlight.cpp
@@ -1,0 +1,139 @@
+#include "guis/GuiMoonlight.h"
+
+#include <algorithm>
+#include <iostream>
+#include <sstream>
+#include <fstream>
+
+#include "Window.h"
+#include "guis/GuiMsgBox.h"
+#include "platform.h"
+#include "Log.h"
+#include "SystemConf.h"
+
+void GuiMoonlight::show(Window* window)
+{
+	window->pushGui(new GuiMoonlight(window));
+}
+
+GuiMoonlight::GuiMoonlight(Window* window)
+ : GuiSettings(window, "MOONLIGHT GAME STREAMING")
+{
+  char pin[5];
+  snprintf(pin, sizeof pin, "%04d", rand() % 10000);
+
+	auto theme = ThemeData::getMenuTheme();
+	std::shared_ptr<Font> font = theme->Text.font;
+	unsigned int color = theme->Text.color;
+	auto pinUI = std::make_shared<TextComponent>(window, pin, font, color);
+
+	addGroup(_("TOOLS"));
+
+  addEntry(_("UPDATE MOONLIGHT GAMES"), false, [window] {
+    std::string server_ip = SystemConf::getInstance()->get("moonlight.host");
+
+    auto lines = executeScript("moonlight list " + server_ip);
+    if (lines.empty()) {
+      window->pushGui(new GuiMsgBox(window, _("Unable to connect to server")));
+    } else if (lines[lines.size() - 1] == "You must pair with the PC first") {
+      window->pushGui(new GuiMsgBox(window, _("Please pair with Moonlight server")));
+    } else {
+
+      executeScript("rm /storage/roms/moonlight/*");
+      executeScript("mkdir -p /storage/roms/moonlight");
+      for (auto app : ParseAppList(lines)) {
+        std::string filename = app;
+        std::replace(filename.begin(), filename.end(), '/', ' ');
+        std::ofstream app_file("/storage/roms/moonlight/" + filename + ".sh");
+        app_file << "#!/bin/bash" << std::endl;
+        app_file << "moonlight stream -app \"" << app << "\" -platform sdl " << server_ip << std::endl;
+        app_file.close();
+      }
+    }
+  });
+
+  addEntry(_("PAIR WITH SERVER"), false, [window, pin] {
+    std::string server_ip = SystemConf::getInstance()->get("moonlight.host");
+
+    char cmd[1024];
+    snprintf(cmd, sizeof cmd, "moonlight pair -pin %s %s", pin, server_ip.c_str());
+		executeScript(cmd, [server_ip, window](std::string line) {
+      std::string new_server_ip;
+      if (ParseServerIp(line, &new_server_ip) && server_ip != new_server_ip) {
+  			SystemConf::getInstance()->set("moonlight.host", new_server_ip);
+	  		SystemConf::getInstance()->saveSystemConf();
+      }
+      const std::string pared_ok = "Succesfully paired";
+      if (line == "Succesfully paired") {
+        window->pushGui(new GuiMsgBox(window, _("Succesfully paired with server")));
+      }
+		});
+	});
+
+  addEntry(_("UNPAIR WITH SERVER"), false, [this, window] {
+		runSystemCommand("rm -r ~/.cache/moonlight", "", nullptr);
+	});
+
+	addGroup(_("SETTINGS"));
+  addInputTextRow(_("SERVER IP"), "moonlight.host", false);
+  addWithLabel(_("PARING PIN"), pinUI);
+}
+
+std::vector<std::string> GuiMoonlight::ParseAppList(const std::vector<std::string>& vec) {
+  std::vector<std::string> apps;
+  for (auto line : vec) {
+    int pos = line.find(". ");
+    if (pos == -1) continue;
+    apps.push_back(line.substr(pos+2));
+  }
+  return apps;
+}
+
+bool GuiMoonlight::ParseServerIp(const std::string& line, std::string* server_ip) {
+  // Watching for "Connect to 10.1.10.217..." line.
+  const std::string prompt = "Connect to ";
+  if (line.find(prompt) != 0) return false;
+
+  const std::string ip = line.substr(prompt.length());
+  if (ip.substr(ip.length() - 3) != "...") return false;
+
+  *server_ip = ip.substr(0, ip.length() - 3);
+  return true;
+}
+
+std::vector<std::string> GuiMoonlight::executeScript(const std::string& command) {
+  std::vector<std::string> vec;
+  executeScript(command, [&vec](const std::string& line) { vec.push_back(line); });
+  return vec;
+}
+
+std::pair<std::string, int> GuiMoonlight::executeScript(const std::string& command, const std::function<void(const std::string)>& func)
+{  
+  std::cout << "executeScript -> " << command << std::endl;
+	LOG(LogInfo) << "executeScript -> " << command;
+
+	FILE *pipe = popen(command.c_str(), "r");
+	if (pipe == NULL)
+	{
+		LOG(LogError) << "Error executing " << command;
+		return std::pair<std::string, int>("Error starting command : " + command, -1);
+	}
+
+  std::stringstream output_stream;
+	char buff[1024];
+	while (fgets(buff, 1024, pipe))
+	{
+    std::stringstream output_stream(buff);
+    std::string line;
+    while (getline(output_stream, line).good()) {
+      if (line.empty()) continue;
+      std::cout << line << std::endl;
+      if (func != nullptr) {
+        func(std::string(line));
+      }
+    }
+	}
+
+	int exitCode = WEXITSTATUS(pclose(pipe));
+	return std::pair<std::string, int>("", exitCode);
+}

--- a/es-app/src/guis/GuiMoonlight.h
+++ b/es-app/src/guis/GuiMoonlight.h
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2022-present kkoshelev
+
 #pragma once
 
 #include "GuiSettings.h"

--- a/es-app/src/guis/GuiMoonlight.h
+++ b/es-app/src/guis/GuiMoonlight.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "GuiSettings.h"
+
+class GuiMoonlight : public GuiSettings 
+{
+public:
+	static void show(Window* window);
+
+protected:
+  GuiMoonlight(Window* window);
+  static std::pair<std::string, int> executeScript(const std::string& command, const std::function<void(const std::string)>& func);
+  static std::vector<std::string> executeScript(const std::string& command);
+  static bool ParseServerIp(const std::string& line, std::string* server_ip);
+  static std::vector<std::string> ParseAppList(const std::vector<std::string>& vec);
+};


### PR DESCRIPTION
# Add Moonlight Game Streaming menu

## Description

This adds additional root menu - Moonlight Game Streaming into Emulation station settings. It allows user to configure Moonlight without a need to use additional scripts.

The following submenus are added
* UPDATE MOONLIGHT GAMES - loads list of all games registered in Moonlight and populates special category for them.
* PAIR WITH SERVER - uses configured server or detects one and initiates paring with the paring code below
* UNPAIR WITH SERVER - removes paring from server
* SERVER IP - allows explicitly specifying server ip
* PARING PIN - pin used to pair with server

Note: changes to distribution repository are in a separate PR.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

New dev build was loaded into RG351V and tested all the menu items separately.

**Test Configuration**: RG351V with custom build
* Build OS name and version: custom build from dev
* Docker (Y/N): N
* JELOS Branch: dev
* Any additional information that may be useful:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
