### PR TITLE
Fix issue where on Window init, the brightness overlay shows

### DIFF
--- a/es-core/src/components/BrightnessInfoComponent.h
+++ b/es-core/src/components/BrightnessInfoComponent.h
@@ -17,7 +17,7 @@ public:
 	void render(const Transform4x4f& parentTrans) override;
 	void update(int deltaTime) override;
 
-	void reset() { mBrightness = 1; }
+	void reset() { mBrightness = -1; }
 
 private:
 	NinePatchComponent* mFrame;


### PR DESCRIPTION
## Description

Fix issue where on Window init, the brightness overlay shows

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested Locally?

Tested on my RG353P off of JELOS dev

**Test Configuration**:
* Build OS name and version: JELOS
* Docker (Y/N): Y
* JELOS Branch: dev

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
