### PR TITLE
Added gamesaves dialog in the emulationstation gamesettings menu

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2346,12 +2346,18 @@ void GuiMenu::openGamesSettings_batocera()
 	incrementalSaveStates->setState(SystemConf::getInstance()->get("global.incrementalsavestates") == "1");
 	s->addWithLabel(_("INCREMENTAL SAVESTATES"), incrementalSaveStates);
 	s->addSaveFunc([incrementalSaveStates] { SystemConf::getInstance()->set("global.incrementalsavestates", incrementalSaveStates->getState() ? "1" : "0"); });
+	
+	// Maximum incremental savestates
+	auto maxIncrementalSaves = std::make_shared<SwitchComponent>(mWindow,"MAX INCREMENTAL SAVESTATES");
+	maxIncrementalSaves->AddRange({ { _("UNLIMITED"), "default" },{ _("1") , "1" },{ _("2") , "2" },{ _("3") , "3" },{ _("5") , "5" },{ _("10") , "10" },{ _("20") , "20" },{ _("50") , "50" },{ _("100") , "100" },{ _("200") , "200" },{ _("500") , "500" },{ _("1000") , "1000" } }, SystemConf::getInstance()->get("global.maxincrementalsaves"));
+	s->addWithLabel(_("MAXIMUM INCREMENTAL SAVESTATES BEFORE ROLLOVER"), maxIncrementalSaves);
+	s->addSaveFunc([maxIncrementalSaves] { SystemConf::getInstance()->set("global.maxincrementalsaves", maxIncrementalSaves->getState() ? "0" : maxIncrementalSaves->getSelected()); });
 
-        // Automated Cloud Backup
-        auto cloudBackup = std::make_shared<SwitchComponent>(mWindow);
-        cloudBackup->setState(SystemConf::getInstance()->get("cloud.backup") == "1");
-        s->addWithLabel(_("BACKUP TO CLOUD ON GAME EXIT"), cloudBackup);
-        s->addSaveFunc([cloudBackup] { SystemConf::getInstance()->set("cloud.backup", cloudBackup->getState() ? "1" : "0"); });
+	// Automated Cloud Backup
+	auto cloudBackup = std::make_shared<SwitchComponent>(mWindow);
+	cloudBackup->setState(SystemConf::getInstance()->get("cloud.backup") == "1");
+	s->addWithLabel(_("BACKUP TO CLOUD ON GAME EXIT"), cloudBackup);
+	s->addSaveFunc([cloudBackup] { SystemConf::getInstance()->set("cloud.backup", cloudBackup->getState() ? "1" : "0"); });
 
 	// Shaders preset
 #ifndef _ENABLEEMUELEC

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2348,10 +2348,10 @@ void GuiMenu::openGamesSettings_batocera()
 	s->addSaveFunc([incrementalSaveStates] { SystemConf::getInstance()->set("global.incrementalsavestates", incrementalSaveStates->getState() ? "1" : "0"); });
 	
 	// Maximum incremental savestates
-	auto maxIncrementalSaves = std::make_shared<SwitchComponent>(mWindow,"MAX INCREMENTAL SAVESTATES");
-	maxIncrementalSaves->AddRange({ { _("UNLIMITED"), "default" },{ _("1") , "1" },{ _("2") , "2" },{ _("3") , "3" },{ _("5") , "5" },{ _("10") , "10" },{ _("20") , "20" },{ _("50") , "50" },{ _("100") , "100" },{ _("200") , "200" },{ _("500") , "500" },{ _("1000") , "1000" } }, SystemConf::getInstance()->get("global.maxincrementalsaves"));
+	auto maxIncrementalSaves = std::make_shared<OptionListComponent<std::string>>(mWindow,"MAX INCREMENTAL SAVESTATES");
+	maxIncrementalSaves->AddRange({ { _("UNLIMITED"), "default" },{ _("2") , "2" },{ _("3") , "3" },{ _("5") , "5" },{ _("10") , "10" },{ _("20") , "20" },{ _("50") , "50" },{ _("100") , "100" },{ _("200") , "200" },{ _("500") , "500" },{ _("1000") , "1000" } }, SystemConf::getInstance()->get("global.maxincrementalsaves"));
 	s->addWithLabel(_("MAXIMUM INCREMENTAL SAVESTATES BEFORE ROLLOVER"), maxIncrementalSaves);
-	s->addSaveFunc([maxIncrementalSaves] { SystemConf::getInstance()->set("global.maxincrementalsaves", maxIncrementalSaves->getState() ? "0" : maxIncrementalSaves->getSelected()); });
+	s->addSaveFunc([maxIncrementalSaves] { SystemConf::getInstance()->set("global.maxincrementalsaves", maxIncrementalSaves->getSelected()); });
 
 	// Automated Cloud Backup
 	auto cloudBackup = std::make_shared<SwitchComponent>(mWindow);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1954,7 +1954,7 @@ void GuiMenu::openSystemSettings_batocera()
 }
 void GuiMenu::openSavestatesConfiguration(Window* mWindow, std::string configName)
 {
-	GuiSettings guiSaves = new GuiSettings(mWindow, _("SAVES CONFIGUREATION").c_str());
+	GuiSettings* guiSaves = new GuiSettings(mWindow, _("SAVES CONFIGUREATION").c_str());
 
 	// autosave/load
 	auto autosave_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("AUTO SAVE/LOAD ON GAME LAUNCH"));

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1954,7 +1954,7 @@ void GuiMenu::openSystemSettings_batocera()
 }
 void GuiMenu::openSavestatesConfiguration(Window* mWindow, std::string configName)
 {
-	Guisettings guiSaves = new GuiSettings(mWindow, _("SAVES CONFIGUREATION").c_str());
+	GuiSettings guiSaves = new GuiSettings(mWindow, _("SAVES CONFIGUREATION").c_str());
 
 	// autosave/load
 	auto autosave_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("AUTO SAVE/LOAD ON GAME LAUNCH"));

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2349,7 +2349,7 @@ void GuiMenu::openGamesSettings_batocera()
 	
 	// Maximum incremental savestates
 	auto maxIncrementalSaves = std::make_shared<OptionListComponent<std::string>>(mWindow,"MAX INCREMENTAL SAVESTATES");
-	maxIncrementalSaves->AddRange({ { _("UNLIMITED"), "default" },{ _("2") , "2" },{ _("3") , "3" },{ _("5") , "5" },{ _("10") , "10" },{ _("20") , "20" },{ _("50") , "50" },{ _("100") , "100" },{ _("200") , "200" },{ _("500") , "500" },{ _("1000") , "1000" } }, SystemConf::getInstance()->get("global.maxincrementalsaves"));
+	maxIncrementalSaves->addRange({ { _("UNLIMITED"), "default" },{ _("2") , "2" },{ _("3") , "3" },{ _("5") , "5" },{ _("10") , "10" },{ _("20") , "20" },{ _("50") , "50" },{ _("100") , "100" },{ _("200") , "200" },{ _("500") , "500" },{ _("1000") , "1000" } }, SystemConf::getInstance()->get("global.maxincrementalsaves"));
 	s->addWithLabel(_("MAXIMUM INCREMENTAL SAVESTATES BEFORE ROLLOVER"), maxIncrementalSaves);
 	s->addSaveFunc([maxIncrementalSaves] { SystemConf::getInstance()->set("global.maxincrementalsaves", maxIncrementalSaves->getSelected()); });
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1943,7 +1943,37 @@ void GuiMenu::openSystemSettings_batocera()
 
 	mWindow->pushGui(s);
 }
+void GuiMenu::openSavestatesConfiguration(Window* mWindow, std::string configName)
+{
+	Guisettings guiSaves = new GuiSettings(mWindow, _("SAVES CONFIGUREATION").c_str());
 
+	// autosave/load
+	auto autosave_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("AUTO SAVE/LOAD ON GAME LAUNCH"));
+	autosave_enabled->addRange({ { _("OFF"), "default" },{ _("ON") , "1" },{ _("SHOW SAVE STATES") , "2" },{ _("SHOW SAVE STATES IF NOT EMPTY") , "3" } }, SystemConf::getInstance()->get("global.autosave"));
+	guiSaves->addWithLabel(_("AUTO SAVE/LOAD ON GAME LAUNCH"), autosave_enabled);
+	guiSaves->addSaveFunc([autosave_enabled] { SystemConf::getInstance()->set("global.autosave", autosave_enabled->getSelected()); });
+
+	// Incremental savestates
+	auto incrementalSaveStates = std::make_shared<SwitchComponent>(mWindow);
+	incrementalSaveStates->setState(SystemConf::getInstance()->get("global.incrementalsavestates") == "1");
+	guiSaves->addWithLabel(_("INCREMENTAL SAVESTATES"), incrementalSaveStates);
+	guiSaves->addSaveFunc([incrementalSaveStates] { SystemConf::getInstance()->set("global.incrementalsavestates", incrementalSaveStates->getState() ? "1" : "0"); });
+	
+	// Maximum incremental savestates
+	auto maxIncrementalSaves = std::make_shared<OptionListComponent<std::string>>(mWindow,"MAX INCREMENTAL SAVESTATES");
+	maxIncrementalSaves->addRange({ { _("UNLIMITED"), "default" },{ _("2") , "2" },{ _("3") , "3" },{ _("5") , "5" },{ _("10") , "10" },{ _("20") , "20" },{ _("50") , "50" },{ _("100") , "100" },{ _("200") , "200" },{ _("500") , "500" },{ _("1000") , "1000" } }, SystemConf::getInstance()->get("global.maxincrementalsaves"));
+	guiSaves->addWithLabel(_("MAX SAVESTATES"), maxIncrementalSaves);
+	guiSaves->addSaveFunc([maxIncrementalSaves] { SystemConf::getInstance()->set("global.maxincrementalsaves", maxIncrementalSaves->getSelected()); });
+
+	// Automated Cloud Backup
+	auto cloudBackup = std::make_shared<SwitchComponent>(mWindow);
+	cloudBackup->setState(SystemConf::getInstance()->get("cloud.backup") == "1");
+	guiSaves->addWithLabel(_("BACKUP TO CLOUD ON GAME EXIT"), cloudBackup);
+	guiSaves->addSaveFunc([cloudBackup] { SystemConf::getInstance()->set("cloud.backup", cloudBackup->getState() ? "1" : "0"); });
+
+	mWindow->pushGui(guiSaves);
+
+}
 void GuiMenu::openLatencyReductionConfiguration(Window* mWindow, std::string configName)
 {
 	GuiSettings* guiLatency = new GuiSettings(mWindow, _("LATENCY REDUCTION").c_str());
@@ -2334,30 +2364,11 @@ void GuiMenu::openGamesSettings_batocera()
 	integerscale_enabled->addRange({ { _("DEFAULT"), "default" },{ _("ON") , "1" },{ _("OFF") , "0" } }, SystemConf::getInstance()->get("global.integerscale"));
 	s->addWithLabel(_("INTEGER SCALING (PIXEL PERFECT)"), integerscale_enabled);
 	s->addSaveFunc([integerscale_enabled] { SystemConf::getInstance()->set("global.integerscale", integerscale_enabled->getSelected()); });
-
-	// autosave/load
-	auto autosave_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("AUTO SAVE/LOAD ON GAME LAUNCH"));
-	autosave_enabled->addRange({ { _("OFF"), "default" },{ _("ON") , "1" },{ _("SHOW SAVE STATES") , "2" },{ _("SHOW SAVE STATES IF NOT EMPTY") , "3" } }, SystemConf::getInstance()->get("global.autosave"));
-	s->addWithLabel(_("AUTO SAVE/LOAD ON GAME LAUNCH"), autosave_enabled);
-	s->addSaveFunc([autosave_enabled] { SystemConf::getInstance()->set("global.autosave", autosave_enabled->getSelected()); });
-
-	// Incremental savestates
-	auto incrementalSaveStates = std::make_shared<SwitchComponent>(mWindow);
-	incrementalSaveStates->setState(SystemConf::getInstance()->get("global.incrementalsavestates") == "1");
-	s->addWithLabel(_("INCREMENTAL SAVESTATES"), incrementalSaveStates);
-	s->addSaveFunc([incrementalSaveStates] { SystemConf::getInstance()->set("global.incrementalsavestates", incrementalSaveStates->getState() ? "1" : "0"); });
 	
-	// Maximum incremental savestates
-	auto maxIncrementalSaves = std::make_shared<OptionListComponent<std::string>>(mWindow,"MAX INCREMENTAL SAVESTATES");
-	maxIncrementalSaves->addRange({ { _("UNLIMITED"), "default" },{ _("2") , "2" },{ _("3") , "3" },{ _("5") , "5" },{ _("10") , "10" },{ _("20") , "20" },{ _("50") , "50" },{ _("100") , "100" },{ _("200") , "200" },{ _("500") , "500" },{ _("1000") , "1000" } }, SystemConf::getInstance()->get("global.maxincrementalsaves"));
-	s->addWithLabel(_("MAXIMUM INCREMENTAL SAVESTATES BEFORE ROLLOVER"), maxIncrementalSaves);
-	s->addSaveFunc([maxIncrementalSaves] { SystemConf::getInstance()->set("global.maxincrementalsaves", maxIncrementalSaves->getSelected()); });
+	// Saves Menu
+	s->addEntry(_("SAVE STATE CONFIG"), true, [this] { openSavestatesConfiguration(mWindow, "global"); });
 
-	// Automated Cloud Backup
-	auto cloudBackup = std::make_shared<SwitchComponent>(mWindow);
-	cloudBackup->setState(SystemConf::getInstance()->get("cloud.backup") == "1");
-	s->addWithLabel(_("BACKUP TO CLOUD ON GAME EXIT"), cloudBackup);
-	s->addSaveFunc([cloudBackup] { SystemConf::getInstance()->set("cloud.backup", cloudBackup->getState() ? "1" : "0"); });
+
 
 	// Shaders preset
 #ifndef _ENABLEEMUELEC

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -99,6 +99,8 @@ private:
 	static std::shared_ptr<OptionListComponent<std::string>> createVideoResolutionModeOptionList(Window *window, std::string configname);
 	static void popSpecificConfigurationGui(Window* mWindow, std::string title, std::string configName, SystemData *systemData, FileData* fileData, bool selectCoreLine = false);
 
+	static void openSavestatesConfiguration(Window* mWindow, std::string configName);
+	
 	static void openLatencyReductionConfiguration(Window* mWindow, std::string configName);
 
 	std::vector<StrInputConfig*> mLoadedInput; // used to keep information about loaded devices in case there are unpluged between device window load and save


### PR DESCRIPTION
# Pull Request Template


I noticed there was a bug in the "setsettings.sh" script. In the "set_savestates" function the retroarch setting "savestate_max_keep" was redundant(it was being changed to 50 when incremental saves were disabled and to 0 when enabled).

I've added a new option "maxIncrementalSaves" to emulationstation and then moved the game save options("autosave_enabled", "incrementalSaveStates",  "maxIncrementalSaves","cloudBackup") all to there own menu "openSavestatesConfiguration" 

Also changed "setsettings.sh" to change "savestate_max_keep" inline with the emulationstation option and changed the default "system.cfg" to include "global.maxincrementalsaves=0"

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested Locally?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested locally on device and everything is working as expected

**Test Configuration**:
* Build OS name and version: Ubuntu 23.04
* Docker (Y):
* JELOS Branch: main
* Any additional information that may be useful:

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas

Note: This PR template is adapted from [embeddedartistry](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE.md)
