### PR TITLE
update mame resources thanks to Batocera

### DIFF
--- a/resources/mamebioses.xml
+++ b/resources/mamebioses.xml
@@ -1,85 +1,88 @@
-<bios>3dobios</bios>
-<bios>airlbios</bios>
-<bios>aleck64</bios>
-<bios>alg_bios</bios>
-<bios>alg3do</bios>
-<bios>allied</bios>
-<bios>ar_bios</bios>
-<bios>aristmk5</bios>
-<bios>aristmk6</bios>
-<bios>atarisy</bios>
-<bios>atarisy1</bios>
-<bios>atluspsx</bios>
-<bios>atpsx</bios>
-<bios>awbios</bios>
-<bios>bctvidbs</bios>
-<bios>bubsys</bios>
-<bios>cd32</bios>
-<bios>cdibios</bios>
-<bios>cedmag</bios>
-<bios>chihiro</bios>
-<bios>coh1000</bios>
-<bios>coh1000a</bios>
-<bios>coh1000c</bios>
-<bios>coh1000t</bios>
-<bios>coh1000w</bios>
-<bios>coh1001l</bios>
-<bios>coh1002e</bios>
-<bios>coh1002m</bios>
-<bios>coh1002v</bios>
-<bios>coh3002c</bios>
-<bios>coh3002t</bios>
-<bios>cpzn1</bios>
-<bios>cpzn2</bios>
-<bios>crysbios</bios>
-<bios>cubo</bios>
-<bios>decocass</bios>
-<bios>f355bios</bios>
-<bios>f355dlx</bios>
-<bios>galgbios</bios>
-<bios>gp_110</bios>
-<bios>gq863</bios>
-<bios>gts1</bios>
-<bios>gts1s</bios>
-<bios>hikaru</bios>
-<bios>hng64</bios>
-<bios>hod2bios</bios>
-<bios>isgsm</bios>
-<bios>iteagle</bios>
-<bios>konamigv</bios>
-<bios>konamigx</bios>
-<bios>kviper</bios>
-<bios>lindbios</bios>
-<bios>mac2bios</bios>
-<bios>macsbios</bios>
-<bios>maxaflex</bios>
-<bios>megaplay</bios>
-<bios>megatech</bios>
-<bios>naomi</bios>
-<bios>naomi2</bios>
-<bios>naomigd</bios>
-<bios>neogeo</bios>
-<bios>nichidvd</bios>
-<bios>nss</bios>
-<bios>pgm</bios>
-<bios>playch10</bios>
-<bios>psarc95</bios>
-<bios>pyson</bios>
-<bios>sammymdl</bios>
-<bios>segasp</bios>
-<bios>sfcbox</bios>
-<bios>shtzone</bios>
-<bios>skns</bios>
-<bios>stvbios</bios>
-<bios>su2000</bios>
-<bios>sys246</bios>
-<bios>sys256</bios>
-<bios>sys573</bios>
-<bios>taitofx1</bios>
-<bios>taitogn</bios>
-<bios>taitotz</bios>
-<bios>tourvis</bios>
-<bios>tps</bios>
-<bios>triforce</bios>
-<bios>v4bios</bios>
-<bios>vspsx</bios>
+<?xml version="1.0" encoding="UTF-8"?>
+<bioses>
+  <bios>3dobios</bios>
+  <bios>airlbios</bios>
+  <bios>aleck64</bios>
+  <bios>alg_bios</bios>
+  <bios>alg3do</bios>
+  <bios>allied</bios>
+  <bios>ar_bios</bios>
+  <bios>aristmk5</bios>
+  <bios>aristmk6</bios>
+  <bios>atarisy</bios>
+  <bios>atarisy1</bios>
+  <bios>atluspsx</bios>
+  <bios>atpsx</bios>
+  <bios>awbios</bios>
+  <bios>bctvidbs</bios>
+  <bios>bubsys</bios>
+  <bios>cd32</bios>
+  <bios>cdibios</bios>
+  <bios>cedmag</bios>
+  <bios>chihiro</bios>
+  <bios>coh1000</bios>
+  <bios>coh1000a</bios>
+  <bios>coh1000c</bios>
+  <bios>coh1000t</bios>
+  <bios>coh1000w</bios>
+  <bios>coh1001l</bios>
+  <bios>coh1002e</bios>
+  <bios>coh1002m</bios>
+  <bios>coh1002v</bios>
+  <bios>coh3002c</bios>
+  <bios>coh3002t</bios>
+  <bios>cpzn1</bios>
+  <bios>cpzn2</bios>
+  <bios>crysbios</bios>
+  <bios>cubo</bios>
+  <bios>decocass</bios>
+  <bios>f355bios</bios>
+  <bios>f355dlx</bios>
+  <bios>galgbios</bios>
+  <bios>gp_110</bios>
+  <bios>gq863</bios>
+  <bios>gts1</bios>
+  <bios>gts1s</bios>
+  <bios>hikaru</bios>
+  <bios>hng64</bios>
+  <bios>hod2bios</bios>
+  <bios>isgsm</bios>
+  <bios>iteagle</bios>
+  <bios>konamigv</bios>
+  <bios>konamigx</bios>
+  <bios>kviper</bios>
+  <bios>lindbios</bios>
+  <bios>mac2bios</bios>
+  <bios>macsbios</bios>
+  <bios>maxaflex</bios>
+  <bios>megaplay</bios>
+  <bios>megatech</bios>
+  <bios>naomi</bios>
+  <bios>naomi2</bios>
+  <bios>naomigd</bios>
+  <bios>neogeo</bios>
+  <bios>nichidvd</bios>
+  <bios>nss</bios>
+  <bios>pgm</bios>
+  <bios>playch10</bios>
+  <bios>psarc95</bios>
+  <bios>pyson</bios>
+  <bios>sammymdl</bios>
+  <bios>segasp</bios>
+  <bios>sfcbox</bios>
+  <bios>shtzone</bios>
+  <bios>skns</bios>
+  <bios>stvbios</bios>
+  <bios>su2000</bios>
+  <bios>sys246</bios>
+  <bios>sys256</bios>
+  <bios>sys573</bios>
+  <bios>taitofx1</bios>
+  <bios>taitogn</bios>
+  <bios>taitotz</bios>
+  <bios>tourvis</bios>
+  <bios>tps</bios>
+  <bios>triforce</bios>
+  <bios>v4bios</bios>
+  <bios>vspsx</bios>
+</bioses>

--- a/resources/mamedevices.xml
+++ b/resources/mamedevices.xml
@@ -1,669 +1,672 @@
-<device>22vp931</device>
-<device>3c505</device>
-<device>a1200kbd_rb</device>
-<device>a1cass</device>
-<device>a2091</device>
-<device>a2232</device>
-<device>a2aevm80</device>
-<device>a2ap16</device>
-<device>a2ap16a</device>
-<device>a2aplcrd</device>
-<device>a2cffa02</device>
-<device>a2cffa2</device>
-<device>a2corvus</device>
-<device>a2diskii</device>
-<device>a2diskiing</device>
-<device>a2hsscsi</device>
-<device>a2iwm_flop</device>
-<device>a2memexp</device>
-<device>a2mouse</device>
-<device>a2pcxport</device>
-<device>a2pic</device>
-<device>a2ramfac</device>
-<device>a2scsi</device>
-<device>a2ssc</device>
-<device>a2swyft</device>
-<device>a2thunpl</device>
-<device>a2tmstho</device>
-<device>a2twarp</device>
-<device>a2ultrme</device>
-<device>a2ulttrm</device>
-<device>a2vidtrm</device>
-<device>a2vtc1</device>
-<device>a2vtc2</device>
-<device>a2vulcan</device>
-<device>a2vulgld</device>
-<device>a2zipdrv</device>
-<device>a3fdc</device>
-<device>a500_kbd_ch</device>
-<device>a500_kbd_de</device>
-<device>a500_kbd_dk</device>
-<device>a500_kbd_es</device>
-<device>a500_kbd_fr</device>
-<device>a500_kbd_gb</device>
-<device>a500_kbd_it</device>
-<device>a500_kbd_no</device>
-<device>a500_kbd_se</device>
-<device>a500_kbd_us</device>
-<device>a590</device>
-<device>a7ports</device>
-<device>abc_fd2</device>
-<device>abc_hdc</device>
-<device>abc_mem</device>
-<device>abc1600mac</device>
-<device>abc1600mover</device>
-<device>abc55</device>
-<device>abc77</device>
-<device>abc800kb</device>
-<device>abc830</device>
-<device>abc832</device>
-<device>abc834</device>
-<device>abc838</device>
-<device>abc850</device>
-<device>abc850flop</device>
-<device>abc852</device>
-<device>abc856</device>
-<device>abc890</device>
-<device>abc894</device>
-<device>abc99</device>
-<device>abcexp</device>
-<device>abcsio</device>
-<device>acorn_econet</device>
-<device>acorn_vdu80</device>
-<device>acorn_vib</device>
-<device>acs8600_ics</device>
-<device>adam_ddp</device>
-<device>adam_fdc</device>
-<device>adam_ide</device>
-<device>adam_kb</device>
-<device>adam_prn</device>
-<device>adam_spi</device>
-<device>aga</device>
-<device>aga_pc200</device>
-<device>agat7_flop</device>
-<device>agat840k_hle</device>
-<device>aha1542</device>
-<device>alto2_cpu</device>
-<device>amiga_ar1</device>
-<device>amiga_ar2</device>
-<device>amiga_ar3</device>
-<device>amigakbd</device>
-<device>ap2000</device>
-<device>at_keybc</device>
-<device>atom_discpack</device>
-<device>atom_econet</device>
-<device>bbc_acorn1770</device>
-<device>bbc_acorn8271</device>
-<device>bbc_beebspch</device>
-<device>bbc_cumana1</device>
-<device>bbc_cumana2</device>
-<device>bbc_cv1797</device>
-<device>bbc_opus1770</device>
-<device>bbc_opus2791</device>
-<device>bbc_opus2793</device>
-<device>bbc_opus3</device>
-<device>bbc_opus8272</device>
-<device>bbc_tube_6502</device>
-<device>bbc_tube_65c102</device>
-<device>bbc_tube_80186</device>
-<device>bbc_tube_80286</device>
-<device>bbc_tube_arm</device>
-<device>bbc_tube_casper</device>
-<device>bbc_tube_z80</device>
-<device>bbc_tube_zep100</device>
-<device>bbc_weddb2</device>
-<device>bbc_weddb3</device>
-<device>beebsid</device>
-<device>betadisk</device>
-<device>bml3kanji</device>
-<device>bml3mp1802</device>
-<device>bml3mp1805</device>
-<device>bsmt2000</device>
-<device>buddha</device>
-<device>bw2_ramcard</device>
-<device>c1526</device>
-<device>c1540</device>
-<device>c1541</device>
-<device>c1541c</device>
-<device>c1541dd</device>
-<device>c1541ii</device>
-<device>c1541pd</device>
-<device>c1541pdc</device>
-<device>c1551</device>
-<device>c1563</device>
-<device>c1570</device>
-<device>c1571</device>
-<device>c1571cr</device>
-<device>c1581</device>
-<device>c2031</device>
-<device>c2040</device>
-<device>c2040_fdc</device>
-<device>c2040fdc</device>
-<device>c3040</device>
-<device>c4023</device>
-<device>c4040</device>
-<device>c64_cs</device>
-<device>c64_fcc</device>
-<device>c64_geocable</device>
-<device>c64_ieee488_device</device>
-<device>c64_magic_voice</device>
-<device>c64_mscr</device>
-<device>c64_music64</device>
-<device>c64_nl10</device>
-<device>c64_sfxse</device>
-<device>c64_supercpu</device>
-<device>c64_swiftlink</device>
-<device>c64_tdos</device>
-<device>c64_turbo232</device>
-<device>c64_xl80</device>
-<device>c8050</device>
-<device>c8050fdc</device>
-<device>c8250</device>
-<device>c8250lp</device>
-<device>c8280</device>
-<device>cadabc</device>
-<device>cbm2_hrga</device>
-<device>cbm2_hrgb</device>
-<device>cbm8000_hsg_a</device>
-<device>cbm8000_hsg_b</device>
-<device>cchip</device>
-<device>cd6809_fdc</device>
-<device>cffa1</device>
-<device>cga</device>
-<device>cga_iskr1030m</device>
-<device>cga_iskr1031</device>
-<device>cga_m24</device>
-<device>cga_mc1502</device>
-<device>cga_poisk2</device>
-<device>cga_superimpose</device>
-<device>cgenie_fdc</device>
-<device>cgenie_printer</device>
-<device>clgd542x</device>
-<device>cmdhd</device>
-<device>cms_4080term</device>
-<device>coco_dcmodem</device>
-<device>coco_fdc</device>
-<device>coco_fdc_v11</device>
-<device>coco_multipack</device>
-<device>coco_orch90</device>
-<device>coco_rs232</device>
-<device>coco_ssc</device>
-<device>coco_t4426</device>
-<device>coco2_hdb1</device>
-<device>coco3_hdb1</device>
-<device>compiskb</device>
-<device>comx_clm</device>
-<device>comx_eb</device>
-<device>comx_epr</device>
-<device>comx_fd</device>
-<device>comx_pl80</device>
-<device>comx_prn</device>
-<device>comx_thm</device>
-<device>cp400_fdc</device>
-<device>cp450_fdc</device>
-<device>cpc_brunword4</device>
-<device>cpc_ddi1</device>
-<device>cpc_dkspeech</device>
-<device>cpc_hd20</device>
-<device>cpc_mf2</device>
-<device>cpc_mface2</device>
-<device>cpc_playcity</device>
-<device>cpc_rom</device>
-<device>cpc_ser</device>
-<device>cpc_serams</device>
-<device>cpc_smartwatch</device>
-<device>cpc_ssa1</device>
-<device>cpc_transtape</device>
-<device>crvfdc01</device>
-<device>crvfdc02</device>
-<device>csd1</device>
-<device>cuda</device>
-<device>d2fdc</device>
-<device>d9060</device>
-<device>d9090</device>
-<device>db411223</device>
-<device>dectalk_isa</device>
-<device>dio98543</device>
-<device>dio98544</device>
-<device>dio98603a</device>
-<device>dio98603b</device>
-<device>dio98644</device>
-<device>diskii13</device>
-<device>dj2db</device>
-<device>djdma</device>
-<device>dm_clgd5430</device>
-<device>dms3d2kp</device>
-<device>dmv_k210</device>
-<device>dmv_k211</device>
-<device>dmv_k212</device>
-<device>dmv_k213</device>
-<device>dmv_k220</device>
-<device>dmv_k230</device>
-<device>dmv_k231</device>
-<device>dmv_k235</device>
-<device>dmv_k801</device>
-<device>dmv_k806</device>
-<device>dmv_keyb</device>
-<device>dmv_keyboard</device>
-<device>dragon_fdc</device>
-<device>dragon_jcbsnd</device>
-<device>dsp1bleg</device>
-<device>dsp1leg</device>
-<device>dsp1leg_hi</device>
-<device>dsp2leg</device>
-<device>dsp3leg</device>
-<device>dsp4leg</device>
-<device>dw_kbd</device>
-<device>e01</device>
-<device>e01s</device>
-<device>ec1840_0002</device>
-<device>ec1841_0002</device>
-<device>ecb_grip21</device>
-<device>econet_e01</device>
-<device>econet_e01s</device>
-<device>ef9340_1</device>
-<device>ef9365</device>
-<device>ega</device>
-<device>egret</device>
-<device>einstein_sd</device>
-<device>einstein_speech</device>
-<device>electron_m2105</device>
-<device>electron_plus1</device>
-<device>electron_plus3</device>
-<device>electron_pwrjoy</device>
-<device>electron_rombox</device>
-<device>electron_romboxp</device>
-<device>ep64_exdos</device>
-<device>epson_pf10</device>
-<device>epson_tf20</device>
-<device>ergoline_kbd</device>
-<device>et4000</device>
-<device>ex800</device>
-<device>fc_disksys</device>
-<device>fccpu20</device>
-<device>fccpu21</device>
-<device>fccpu21a</device>
-<device>fccpu21b</device>
-<device>fccpu21s</device>
-<device>fccpu21ya</device>
-<device>fccpu21yb</device>
-<device>fcisio1</device>
-<device>fcscsi1</device>
-<device>fd2000</device>
-<device>fd4000</device>
-<device>fdc344</device>
-<device>fdc37c93x</device>
-<device>fdcmag</device>
-<device>filetto_cga</device>
-<device>finalchs</device>
-<device>fsd1</device>
-<device>fsd2</device>
-<device>gfxultra</device>
-<device>gfxultrap</device>
-<device>gfxultrp</device>
-<device>gic</device>
-<device>grip</device>
-<device>hardbox</device>
-<device>harddriv_board</device>
-<device>harddrivc_board</device>
-<device>hcpu30</device>
-<device>hd44780_a00</device>
-<device>hd61830</device>
-<device>hdc</device>
-<device>hdc_ec1841</device>
-<device>hdrivair_board</device>
-<device>hdrivairp_board</device>
-<device>hp82937</device>
-<device>hp9122c</device>
-<device>hp98034</device>
-<device>hp98035</device>
-<device>hp9845_prt</device>
-<device>hp9895</device>
-<device>i82371ab</device>
-<device>ibm_mfc</device>
-<device>ibm_vga</device>
-<device>ie15_device</device>
-<device>ie15_keyboard</device>
-<device>ie15_terminal</device>
-<device>ie15kbd</device>
-<device>imi5000h</device>
-<device>indusgt</device>
-<device>interpod</device>
-<device>intv_ecs</device>
-<device>intv_voice</device>
-<device>ioc2f</device>
-<device>ioc2g</device>
-<device>iq151_disc2</device>
-<device>iq151_minigraf</device>
-<device>iq151_ms151a</device>
-<device>iq151_ms15a</device>
-<device>iq151_video32</device>
-<device>iq151_video64</device>
-<device>isa_finalchs</device>
-<device>isa_hdc</device>
-<device>isa_hdc_ec1841</device>
-<device>isa_hercules</device>
-<device>isa_ibm_mda</device>
-<device>isa_ibm_pgc</device>
-<device>isa_lpt</device>
-<device>isa_mpu401</device>
-<device>isbc_215g</device>
-<device>iteagle_fpga</device>
-<device>jasmin</device>
-<device>jvs13551</device>
-<device>k573_dio</device>
-<device>k573dio</device>
-<device>k573mcr</device>
-<device>k573msu</device>
-<device>k573npu</device>
-<device>k7659_keyboard</device>
-<device>k7659kb</device>
-<device>kaypro10kbd</device>
-<device>kb_3270pc</device>
-<device>kb_ec1841</device>
-<device>kb_iskr1030</device>
-<device>kb_ms_natural</device>
-<device>kb_pcat84</device>
-<device>kb_pcxt83</device>
-<device>kbd_lle_en_us</device>
-<device>kc_d002</device>
-<device>kc_d004</device>
-<device>kc_d004_gide</device>
-<device>kc_d004gide</device>
-<device>keytronic_pc3270</device>
-<device>keytronic_pc3270_at</device>
-<device>km035</device>
-<device>ks0066_f05</device>
-<device>laserfdc</device>
-<device>lba_enhancer</device>
-<device>ldv1000</device>
-<device>list.txt</device>
-<device>lk201</device>
-<device>lux10828</device>
-<device>lux21046</device>
-<device>lux21056</device>
-<device>lux4105</device>
-<device>lx800</device>
-<device>lx810l</device>
-<device>m1comm</device>
-<device>m20_8086</device>
-<device>m24_kbd</device>
-<device>m24_z8000</device>
-<device>m50458</device>
-<device>m68705p3</device>
-<device>m68705p5</device>
-<device>m68705r3</device>
-<device>m68705u</device>
-<device>m68705u3</device>
-<device>mach64</device>
-<device>mach64isa</device>
-<device>mackbd</device>
-<device>mc1502_rom</device>
-<device>microdisc</device>
-<device>midcsd</device>
-<device>midssio</device>
-<device>mie</device>
-<device>minichif</device>
-<device>mm1kb</device>
-<device>mm5740</device>
-<device>model1io</device>
-<device>model1io2</device>
-<device>mpcb828</device>
-<device>mpcb849</device>
-<device>mpcb896</device>
-<device>mpcb963</device>
-<device>mpcba79</device>
-<device>mpcbb92</device>
-<device>mpu_pc98</device>
-<device>mpu401</device>
-<device>ms_natural</device>
-<device>ms7004</device>
-<device>mshark</device>
-<device>msm6222b</device>
-<device>msm6222b01</device>
-<device>msmt070</device>
-<device>msmt071</device>
-<device>msmt081</device>
-<device>msmt094</device>
-<device>msx_cart_bm_012</device>
-<device>msx_cart_sfg01</device>
-<device>msx_cart_sfg05</device>
-<device>msx_moonsound</device>
-<device>mvme350</device>
-<device>mzr8300</device>
-<device>namco50</device>
-<device>namco51</device>
-<device>namco52</device>
-<device>namco53</device>
-<device>namco54</device>
-<device>namco62</device>
-<device>namcoc65</device>
-<device>namcoc68</device>
-<device>namcoc69</device>
-<device>namcoc70</device>
-<device>namcoc74</device>
-<device>namcoc75</device>
-<device>namcoc76</device>
-<device>nb_48gc</device>
-<device>nb_824gc</device>
-<device>nb_aenet</device>
-<device>nb_amc3b</device>
-<device>nb_btbug</device>
-<device>nb_c264</device>
-<device>nb_cb264</device>
-<device>nb_image</device>
-<device>nb_m2hr</device>
-<device>nb_m2vc</device>
-<device>nb_qdlink</device>
-<device>nb_rtpd</device>
-<device>nb_sp8s3</device>
-<device>nb_spdq</device>
-<device>nb_vikbw</device>
-<device>nb_wspt</device>
-<device>newbrain_eim</device>
-<device>newbrain_fdc</device>
-<device>nmk004</device>
-<device>nsmdsa</device>
-<device>nsmdsad</device>
-<device>o2_voice</device>
-<device>omti8621isa</device>
-<device>p1_fdc</device>
-<device>p1_hdc</device>
-<device>p1_rom</device>
-<device>p72</device>
-<device>pc_lpt</device>
-<device>pc1512kb</device>
-<device>pc1640_iga</device>
-<device>pc9801_26</device>
-<device>pc9801_86</device>
-<device>pc9801_spb</device>
-<device>pcd_kbd</device>
-<device>pcd_video</device>
-<device>pcx_video</device>
-<device>pd3_30hr</device>
-<device>pd3_c264</device>
-<device>pd3_lviw</device>
-<device>pd3_mclr</device>
-<device>pd3_pc16</device>
-<device>pdc</device>
-<device>pds_sefp</device>
-<device>peribox</device>
-<device>peribox_ev</device>
-<device>peribox_gen</device>
-<device>peribox_genmod</device>
-<device>peribox_sg</device>
-<device>pet_softbox</device>
-<device>pet_superpet</device>
-<device>pofo_hpc101</device>
-<device>pofo_hpc102</device>
-<device>pofo_hpc104</device>
-<device>pofo_hpc104_2</device>
-<device>pr8210</device>
-<device>premier_fdc</device>
-<device>psx_cd</device>
-<device>psxgboost</device>
-<device>px320a</device>
-<device>ql_cumanafdi</device>
-<device>ql_gold</device>
-<device>ql_kdi</device>
-<device>ql_mhd</device>
-<device>ql_mpfdi</device>
-<device>ql_opdbm</device>
-<device>ql_pcmlqdi</device>
-<device>ql_qdisc</device>
-<device>ql_qldisc</device>
-<device>ql_qplus4</device>
-<device>ql_qubide</device>
-<device>ql_sdisk</device>
-<device>ql_sqboard256</device>
-<device>ql_sqboard512</device>
-<device>ql_sqmouse</device>
-<device>ql_sqmouse512</device>
-<device>ql_trump</device>
-<device>ql_trump256</device>
-<device>ql_trump512</device>
-<device>ql_trump768</device>
-<device>qsound</device>
-<device>qsound_hle</device>
-<device>racedriv_board</device>
-<device>racedrivb1_board</device>
-<device>racedrivc_board</device>
-<device>racedrivc_panorama_side_board</device>
-<device>racedrivc1_board</device>
-<device>rolm_pdc</device>
-<device>rolm_smioc</device>
-<device>s100_djdma</device>
-<device>s100_nsmdsa</device>
-<device>s100_nsmdsad</device>
-<device>s100_sj2db</device>
-<device>s100_wunderbus</device>
-<device>s1410</device>
-<device>s3_764</device>
-<device>s3virge</device>
-<device>s3virgedx</device>
-<device>s97269pb</device>
-<device>saa5050</device>
-<device>saa5051</device>
-<device>saa5052</device>
-<device>saa5053</device>
-<device>saa5054</device>
-<device>saa5055</device>
-<device>saa5056</device>
-<device>saa5057</device>
-<device>sad8852</device>
-<device>satcdb</device>
-<device>sb16</device>
-<device>sdtandy_fdc</device>
-<device>sed1200</device>
-<device>sed1200da</device>
-<device>sed1200db</device>
-<device>sed1200fa</device>
-<device>sed1200fb</device>
-<device>segabill</device>
-<device>segadimm</device>
-<device>seganetw</device>
-<device>serbox</device>
-<device>seta10leg</device>
-<device>seta11leg</device>
-<device>sfd10001</device>
-<device>sfd1001</device>
-<device>side116</device>
-<device>simutrek</device>
-<device>slutprov</device>
-<device>sns_dsp1bleg</device>
-<device>sns_dsp1leg</device>
-<device>sns_dsp1leg_hi</device>
-<device>sns_dsp2leg</device>
-<device>sns_dsp3leg</device>
-<device>sns_dsp4leg</device>
-<device>sns_rom_sgb</device>
-<device>sns_rom_sgb2</device>
-<device>sns_seta10leg</device>
-<device>sns_seta11leg</device>
-<device>spc1000_fdd_exp</device>
-<device>spectrum_fuller</device>
-<device>spectrum_intf1</device>
-<device>spectrum_melodik</device>
-<device>spectrum_mikroplus</device>
-<device>spectrum_plus2test</device>
-<device>spectrum_uslot</device>
-<device>spectrum_usource</device>
-<device>spectrum_uspeech</device>
-<device>ss50_mpc</device>
-<device>ss50_mps</device>
-<device>steeltal_board</device>
-<device>steeltal1_board</device>
-<device>steeltalp_board</device>
-<device>stereo_fx</device>
-<device>stic</device>
-<device>strtdriv_board</device>
-<device>stunrun_board</device>
-<device>sv601</device>
-<device>sv602</device>
-<device>sv603</device>
-<device>sv802</device>
-<device>sv805</device>
-<device>sv806</device>
-<device>sx1541</device>
-<device>t5182</device>
-<device>tetriskr_cga</device>
-<device>tgui9680</device>
-<device>ti_hx5102</device>
-<device>ti8x_glinkhle</device>
-<device>ti8x_tconn</device>
-<device>ti99_bwg</device>
-<device>ti99_evpc</device>
-<device>ti99_fdc</device>
-<device>ti99_gkracker</device>
-<device>ti99_hfdc</device>
-<device>ti99_myarcmem</device>
-<device>ti99_pcode</device>
-<device>ti99_rs232</device>
-<device>ti99_speech</device>
-<device>tiki100_8088</device>
-<device>tk02</device>
-<device>tms32030</device>
-<device>tms32031</device>
-<device>tms32032</device>
-<device>to7_io_line</device>
-<device>trs80m2kb</device>
-<device>tvc_hbf</device>
-<device>uni800</device>
-<device>unidisk</device>
-<device>upd7220</device>
-<device>vic1010</device>
-<device>vic1011</device>
-<device>vic1112</device>
-<device>vic1515</device>
-<device>vic1520</device>
-<device>vic20_fe3</device>
-<device>vic20_videopak</device>
-<device>victor9k_fdc</device>
-<device>victor9k_kb</device>
-<device>victor9kb</device>
-<device>votrax</device>
-<device>vp575</device>
-<device>vp700</device>
-<device>vrc5074</device>
-<device>vtech_fdc</device>
-<device>vtech_printer</device>
-<device>vtech_rs232</device>
-<device>vtech_rtty</device>
-<device>vtech_wordpro</device>
-<device>vz_rs232</device>
-<device>vz_rtty</device>
-<device>wangpc_lic</device>
-<device>wangpc_rtc</device>
-<device>wangpc_wdc</device>
-<device>wangpckb</device>
-<device>wd1002a_wx1</device>
-<device>wd1007a</device>
-<device>wdxt_gen</device>
-<device>wordpro</device>
-<device>wyse700</device>
-<device>x68k_cz6bs1</device>
-<device>x820kb</device>
-<device>xtide</device>
-<device>ym2608</device>
-<device>z8671</device>
-<device>zorba_kbd</device>
+<?xml version="1.0" encoding="UTF-8"?>
+<devices>
+  <device>22vp931</device>
+  <device>3c505</device>
+  <device>a1200kbd_rb</device>
+  <device>a1cass</device>
+  <device>a2091</device>
+  <device>a2232</device>
+  <device>a2aevm80</device>
+  <device>a2ap16</device>
+  <device>a2ap16a</device>
+  <device>a2aplcrd</device>
+  <device>a2cffa02</device>
+  <device>a2cffa2</device>
+  <device>a2corvus</device>
+  <device>a2diskii</device>
+  <device>a2diskiing</device>
+  <device>a2hsscsi</device>
+  <device>a2iwm_flop</device>
+  <device>a2memexp</device>
+  <device>a2mouse</device>
+  <device>a2pcxport</device>
+  <device>a2pic</device>
+  <device>a2ramfac</device>
+  <device>a2scsi</device>
+  <device>a2ssc</device>
+  <device>a2swyft</device>
+  <device>a2thunpl</device>
+  <device>a2tmstho</device>
+  <device>a2twarp</device>
+  <device>a2ultrme</device>
+  <device>a2ulttrm</device>
+  <device>a2vidtrm</device>
+  <device>a2vtc1</device>
+  <device>a2vtc2</device>
+  <device>a2vulcan</device>
+  <device>a2vulgld</device>
+  <device>a2zipdrv</device>
+  <device>a3fdc</device>
+  <device>a500_kbd_ch</device>
+  <device>a500_kbd_de</device>
+  <device>a500_kbd_dk</device>
+  <device>a500_kbd_es</device>
+  <device>a500_kbd_fr</device>
+  <device>a500_kbd_gb</device>
+  <device>a500_kbd_it</device>
+  <device>a500_kbd_no</device>
+  <device>a500_kbd_se</device>
+  <device>a500_kbd_us</device>
+  <device>a590</device>
+  <device>a7ports</device>
+  <device>abc_fd2</device>
+  <device>abc_hdc</device>
+  <device>abc_mem</device>
+  <device>abc1600mac</device>
+  <device>abc1600mover</device>
+  <device>abc55</device>
+  <device>abc77</device>
+  <device>abc800kb</device>
+  <device>abc830</device>
+  <device>abc832</device>
+  <device>abc834</device>
+  <device>abc838</device>
+  <device>abc850</device>
+  <device>abc850flop</device>
+  <device>abc852</device>
+  <device>abc856</device>
+  <device>abc890</device>
+  <device>abc894</device>
+  <device>abc99</device>
+  <device>abcexp</device>
+  <device>abcsio</device>
+  <device>acorn_econet</device>
+  <device>acorn_vdu80</device>
+  <device>acorn_vib</device>
+  <device>acs8600_ics</device>
+  <device>adam_ddp</device>
+  <device>adam_fdc</device>
+  <device>adam_ide</device>
+  <device>adam_kb</device>
+  <device>adam_prn</device>
+  <device>adam_spi</device>
+  <device>aga</device>
+  <device>aga_pc200</device>
+  <device>agat7_flop</device>
+  <device>agat840k_hle</device>
+  <device>aha1542</device>
+  <device>alto2_cpu</device>
+  <device>amiga_ar1</device>
+  <device>amiga_ar2</device>
+  <device>amiga_ar3</device>
+  <device>amigakbd</device>
+  <device>ap2000</device>
+  <device>at_keybc</device>
+  <device>atom_discpack</device>
+  <device>atom_econet</device>
+  <device>bbc_acorn1770</device>
+  <device>bbc_acorn8271</device>
+  <device>bbc_beebspch</device>
+  <device>bbc_cumana1</device>
+  <device>bbc_cumana2</device>
+  <device>bbc_cv1797</device>
+  <device>bbc_opus1770</device>
+  <device>bbc_opus2791</device>
+  <device>bbc_opus2793</device>
+  <device>bbc_opus3</device>
+  <device>bbc_opus8272</device>
+  <device>bbc_tube_6502</device>
+  <device>bbc_tube_65c102</device>
+  <device>bbc_tube_80186</device>
+  <device>bbc_tube_80286</device>
+  <device>bbc_tube_arm</device>
+  <device>bbc_tube_casper</device>
+  <device>bbc_tube_z80</device>
+  <device>bbc_tube_zep100</device>
+  <device>bbc_weddb2</device>
+  <device>bbc_weddb3</device>
+  <device>beebsid</device>
+  <device>betadisk</device>
+  <device>bml3kanji</device>
+  <device>bml3mp1802</device>
+  <device>bml3mp1805</device>
+  <device>bsmt2000</device>
+  <device>buddha</device>
+  <device>bw2_ramcard</device>
+  <device>c1526</device>
+  <device>c1540</device>
+  <device>c1541</device>
+  <device>c1541c</device>
+  <device>c1541dd</device>
+  <device>c1541ii</device>
+  <device>c1541pd</device>
+  <device>c1541pdc</device>
+  <device>c1551</device>
+  <device>c1563</device>
+  <device>c1570</device>
+  <device>c1571</device>
+  <device>c1571cr</device>
+  <device>c1581</device>
+  <device>c2031</device>
+  <device>c2040</device>
+  <device>c2040_fdc</device>
+  <device>c2040fdc</device>
+  <device>c3040</device>
+  <device>c4023</device>
+  <device>c4040</device>
+  <device>c64_cs</device>
+  <device>c64_fcc</device>
+  <device>c64_geocable</device>
+  <device>c64_ieee488_device</device>
+  <device>c64_magic_voice</device>
+  <device>c64_mscr</device>
+  <device>c64_music64</device>
+  <device>c64_nl10</device>
+  <device>c64_sfxse</device>
+  <device>c64_supercpu</device>
+  <device>c64_swiftlink</device>
+  <device>c64_tdos</device>
+  <device>c64_turbo232</device>
+  <device>c64_xl80</device>
+  <device>c8050</device>
+  <device>c8050fdc</device>
+  <device>c8250</device>
+  <device>c8250lp</device>
+  <device>c8280</device>
+  <device>cadabc</device>
+  <device>cbm2_hrga</device>
+  <device>cbm2_hrgb</device>
+  <device>cbm8000_hsg_a</device>
+  <device>cbm8000_hsg_b</device>
+  <device>cchip</device>
+  <device>cd6809_fdc</device>
+  <device>cffa1</device>
+  <device>cga</device>
+  <device>cga_iskr1030m</device>
+  <device>cga_iskr1031</device>
+  <device>cga_m24</device>
+  <device>cga_mc1502</device>
+  <device>cga_poisk2</device>
+  <device>cga_superimpose</device>
+  <device>cgenie_fdc</device>
+  <device>cgenie_printer</device>
+  <device>clgd542x</device>
+  <device>cmdhd</device>
+  <device>cms_4080term</device>
+  <device>coco_dcmodem</device>
+  <device>coco_fdc</device>
+  <device>coco_fdc_v11</device>
+  <device>coco_multipack</device>
+  <device>coco_orch90</device>
+  <device>coco_rs232</device>
+  <device>coco_ssc</device>
+  <device>coco_t4426</device>
+  <device>coco2_hdb1</device>
+  <device>coco3_hdb1</device>
+  <device>compiskb</device>
+  <device>comx_clm</device>
+  <device>comx_eb</device>
+  <device>comx_epr</device>
+  <device>comx_fd</device>
+  <device>comx_pl80</device>
+  <device>comx_prn</device>
+  <device>comx_thm</device>
+  <device>cp400_fdc</device>
+  <device>cp450_fdc</device>
+  <device>cpc_brunword4</device>
+  <device>cpc_ddi1</device>
+  <device>cpc_dkspeech</device>
+  <device>cpc_hd20</device>
+  <device>cpc_mf2</device>
+  <device>cpc_mface2</device>
+  <device>cpc_playcity</device>
+  <device>cpc_rom</device>
+  <device>cpc_ser</device>
+  <device>cpc_serams</device>
+  <device>cpc_smartwatch</device>
+  <device>cpc_ssa1</device>
+  <device>cpc_transtape</device>
+  <device>crvfdc01</device>
+  <device>crvfdc02</device>
+  <device>csd1</device>
+  <device>cuda</device>
+  <device>d2fdc</device>
+  <device>d9060</device>
+  <device>d9090</device>
+  <device>db411223</device>
+  <device>dectalk_isa</device>
+  <device>dio98543</device>
+  <device>dio98544</device>
+  <device>dio98603a</device>
+  <device>dio98603b</device>
+  <device>dio98644</device>
+  <device>diskii13</device>
+  <device>dj2db</device>
+  <device>djdma</device>
+  <device>dm_clgd5430</device>
+  <device>dms3d2kp</device>
+  <device>dmv_k210</device>
+  <device>dmv_k211</device>
+  <device>dmv_k212</device>
+  <device>dmv_k213</device>
+  <device>dmv_k220</device>
+  <device>dmv_k230</device>
+  <device>dmv_k231</device>
+  <device>dmv_k235</device>
+  <device>dmv_k801</device>
+  <device>dmv_k806</device>
+  <device>dmv_keyb</device>
+  <device>dmv_keyboard</device>
+  <device>dragon_fdc</device>
+  <device>dragon_jcbsnd</device>
+  <device>dsp1bleg</device>
+  <device>dsp1leg</device>
+  <device>dsp1leg_hi</device>
+  <device>dsp2leg</device>
+  <device>dsp3leg</device>
+  <device>dsp4leg</device>
+  <device>dw_kbd</device>
+  <device>e01</device>
+  <device>e01s</device>
+  <device>ec1840_0002</device>
+  <device>ec1841_0002</device>
+  <device>ecb_grip21</device>
+  <device>econet_e01</device>
+  <device>econet_e01s</device>
+  <device>ef9340_1</device>
+  <device>ef9365</device>
+  <device>ega</device>
+  <device>egret</device>
+  <device>einstein_sd</device>
+  <device>einstein_speech</device>
+  <device>electron_m2105</device>
+  <device>electron_plus1</device>
+  <device>electron_plus3</device>
+  <device>electron_pwrjoy</device>
+  <device>electron_rombox</device>
+  <device>electron_romboxp</device>
+  <device>ep64_exdos</device>
+  <device>epson_pf10</device>
+  <device>epson_tf20</device>
+  <device>ergoline_kbd</device>
+  <device>et4000</device>
+  <device>ex800</device>
+  <device>fc_disksys</device>
+  <device>fccpu20</device>
+  <device>fccpu21</device>
+  <device>fccpu21a</device>
+  <device>fccpu21b</device>
+  <device>fccpu21s</device>
+  <device>fccpu21ya</device>
+  <device>fccpu21yb</device>
+  <device>fcisio1</device>
+  <device>fcscsi1</device>
+  <device>fd2000</device>
+  <device>fd4000</device>
+  <device>fdc344</device>
+  <device>fdc37c93x</device>
+  <device>fdcmag</device>
+  <device>filetto_cga</device>
+  <device>finalchs</device>
+  <device>fsd1</device>
+  <device>fsd2</device>
+  <device>gfxultra</device>
+  <device>gfxultrap</device>
+  <device>gfxultrp</device>
+  <device>gic</device>
+  <device>grip</device>
+  <device>hardbox</device>
+  <device>harddriv_board</device>
+  <device>harddrivc_board</device>
+  <device>hcpu30</device>
+  <device>hd44780_a00</device>
+  <device>hd61830</device>
+  <device>hdc</device>
+  <device>hdc_ec1841</device>
+  <device>hdrivair_board</device>
+  <device>hdrivairp_board</device>
+  <device>hp82937</device>
+  <device>hp9122c</device>
+  <device>hp98034</device>
+  <device>hp98035</device>
+  <device>hp9845_prt</device>
+  <device>hp9895</device>
+  <device>i82371ab</device>
+  <device>ibm_mfc</device>
+  <device>ibm_vga</device>
+  <device>ie15_device</device>
+  <device>ie15_keyboard</device>
+  <device>ie15_terminal</device>
+  <device>ie15kbd</device>
+  <device>imi5000h</device>
+  <device>indusgt</device>
+  <device>interpod</device>
+  <device>intv_ecs</device>
+  <device>intv_voice</device>
+  <device>ioc2f</device>
+  <device>ioc2g</device>
+  <device>iq151_disc2</device>
+  <device>iq151_minigraf</device>
+  <device>iq151_ms151a</device>
+  <device>iq151_ms15a</device>
+  <device>iq151_video32</device>
+  <device>iq151_video64</device>
+  <device>isa_finalchs</device>
+  <device>isa_hdc</device>
+  <device>isa_hdc_ec1841</device>
+  <device>isa_hercules</device>
+  <device>isa_ibm_mda</device>
+  <device>isa_ibm_pgc</device>
+  <device>isa_lpt</device>
+  <device>isa_mpu401</device>
+  <device>isbc_215g</device>
+  <device>iteagle_fpga</device>
+  <device>jasmin</device>
+  <device>jvs13551</device>
+  <device>k573_dio</device>
+  <device>k573dio</device>
+  <device>k573mcr</device>
+  <device>k573msu</device>
+  <device>k573npu</device>
+  <device>k7659_keyboard</device>
+  <device>k7659kb</device>
+  <device>kaypro10kbd</device>
+  <device>kb_3270pc</device>
+  <device>kb_ec1841</device>
+  <device>kb_iskr1030</device>
+  <device>kb_ms_natural</device>
+  <device>kb_pcat84</device>
+  <device>kb_pcxt83</device>
+  <device>kbd_lle_en_us</device>
+  <device>kc_d002</device>
+  <device>kc_d004</device>
+  <device>kc_d004_gide</device>
+  <device>kc_d004gide</device>
+  <device>keytronic_pc3270</device>
+  <device>keytronic_pc3270_at</device>
+  <device>km035</device>
+  <device>ks0066_f05</device>
+  <device>laserfdc</device>
+  <device>lba_enhancer</device>
+  <device>ldv1000</device>
+  <device>list.txt</device>
+  <device>lk201</device>
+  <device>lux10828</device>
+  <device>lux21046</device>
+  <device>lux21056</device>
+  <device>lux4105</device>
+  <device>lx800</device>
+  <device>lx810l</device>
+  <device>m1comm</device>
+  <device>m20_8086</device>
+  <device>m24_kbd</device>
+  <device>m24_z8000</device>
+  <device>m50458</device>
+  <device>m68705p3</device>
+  <device>m68705p5</device>
+  <device>m68705r3</device>
+  <device>m68705u</device>
+  <device>m68705u3</device>
+  <device>mach64</device>
+  <device>mach64isa</device>
+  <device>mackbd</device>
+  <device>mc1502_rom</device>
+  <device>microdisc</device>
+  <device>midcsd</device>
+  <device>midssio</device>
+  <device>mie</device>
+  <device>minichif</device>
+  <device>mm1kb</device>
+  <device>mm5740</device>
+  <device>model1io</device>
+  <device>model1io2</device>
+  <device>mpcb828</device>
+  <device>mpcb849</device>
+  <device>mpcb896</device>
+  <device>mpcb963</device>
+  <device>mpcba79</device>
+  <device>mpcbb92</device>
+  <device>mpu_pc98</device>
+  <device>mpu401</device>
+  <device>ms_natural</device>
+  <device>ms7004</device>
+  <device>mshark</device>
+  <device>msm6222b</device>
+  <device>msm6222b01</device>
+  <device>msmt070</device>
+  <device>msmt071</device>
+  <device>msmt081</device>
+  <device>msmt094</device>
+  <device>msx_cart_bm_012</device>
+  <device>msx_cart_sfg01</device>
+  <device>msx_cart_sfg05</device>
+  <device>msx_moonsound</device>
+  <device>mvme350</device>
+  <device>mzr8300</device>
+  <device>namco50</device>
+  <device>namco51</device>
+  <device>namco52</device>
+  <device>namco53</device>
+  <device>namco54</device>
+  <device>namco62</device>
+  <device>namcoc65</device>
+  <device>namcoc68</device>
+  <device>namcoc69</device>
+  <device>namcoc70</device>
+  <device>namcoc74</device>
+  <device>namcoc75</device>
+  <device>namcoc76</device>
+  <device>nb_48gc</device>
+  <device>nb_824gc</device>
+  <device>nb_aenet</device>
+  <device>nb_amc3b</device>
+  <device>nb_btbug</device>
+  <device>nb_c264</device>
+  <device>nb_cb264</device>
+  <device>nb_image</device>
+  <device>nb_m2hr</device>
+  <device>nb_m2vc</device>
+  <device>nb_qdlink</device>
+  <device>nb_rtpd</device>
+  <device>nb_sp8s3</device>
+  <device>nb_spdq</device>
+  <device>nb_vikbw</device>
+  <device>nb_wspt</device>
+  <device>newbrain_eim</device>
+  <device>newbrain_fdc</device>
+  <device>nmk004</device>
+  <device>nsmdsa</device>
+  <device>nsmdsad</device>
+  <device>o2_voice</device>
+  <device>omti8621isa</device>
+  <device>p1_fdc</device>
+  <device>p1_hdc</device>
+  <device>p1_rom</device>
+  <device>p72</device>
+  <device>pc_lpt</device>
+  <device>pc1512kb</device>
+  <device>pc1640_iga</device>
+  <device>pc9801_26</device>
+  <device>pc9801_86</device>
+  <device>pc9801_spb</device>
+  <device>pcd_kbd</device>
+  <device>pcd_video</device>
+  <device>pcx_video</device>
+  <device>pd3_30hr</device>
+  <device>pd3_c264</device>
+  <device>pd3_lviw</device>
+  <device>pd3_mclr</device>
+  <device>pd3_pc16</device>
+  <device>pdc</device>
+  <device>pds_sefp</device>
+  <device>peribox</device>
+  <device>peribox_ev</device>
+  <device>peribox_gen</device>
+  <device>peribox_genmod</device>
+  <device>peribox_sg</device>
+  <device>pet_softbox</device>
+  <device>pet_superpet</device>
+  <device>pofo_hpc101</device>
+  <device>pofo_hpc102</device>
+  <device>pofo_hpc104</device>
+  <device>pofo_hpc104_2</device>
+  <device>pr8210</device>
+  <device>premier_fdc</device>
+  <device>psx_cd</device>
+  <device>psxgboost</device>
+  <device>px320a</device>
+  <device>ql_cumanafdi</device>
+  <device>ql_gold</device>
+  <device>ql_kdi</device>
+  <device>ql_mhd</device>
+  <device>ql_mpfdi</device>
+  <device>ql_opdbm</device>
+  <device>ql_pcmlqdi</device>
+  <device>ql_qdisc</device>
+  <device>ql_qldisc</device>
+  <device>ql_qplus4</device>
+  <device>ql_qubide</device>
+  <device>ql_sdisk</device>
+  <device>ql_sqboard256</device>
+  <device>ql_sqboard512</device>
+  <device>ql_sqmouse</device>
+  <device>ql_sqmouse512</device>
+  <device>ql_trump</device>
+  <device>ql_trump256</device>
+  <device>ql_trump512</device>
+  <device>ql_trump768</device>
+  <device>qsound</device>
+  <device>qsound_hle</device>
+  <device>racedriv_board</device>
+  <device>racedrivb1_board</device>
+  <device>racedrivc_board</device>
+  <device>racedrivc_panorama_side_board</device>
+  <device>racedrivc1_board</device>
+  <device>rolm_pdc</device>
+  <device>rolm_smioc</device>
+  <device>s100_djdma</device>
+  <device>s100_nsmdsa</device>
+  <device>s100_nsmdsad</device>
+  <device>s100_sj2db</device>
+  <device>s100_wunderbus</device>
+  <device>s1410</device>
+  <device>s3_764</device>
+  <device>s3virge</device>
+  <device>s3virgedx</device>
+  <device>s97269pb</device>
+  <device>saa5050</device>
+  <device>saa5051</device>
+  <device>saa5052</device>
+  <device>saa5053</device>
+  <device>saa5054</device>
+  <device>saa5055</device>
+  <device>saa5056</device>
+  <device>saa5057</device>
+  <device>sad8852</device>
+  <device>satcdb</device>
+  <device>sb16</device>
+  <device>sdtandy_fdc</device>
+  <device>sed1200</device>
+  <device>sed1200da</device>
+  <device>sed1200db</device>
+  <device>sed1200fa</device>
+  <device>sed1200fb</device>
+  <device>segabill</device>
+  <device>segadimm</device>
+  <device>seganetw</device>
+  <device>serbox</device>
+  <device>seta10leg</device>
+  <device>seta11leg</device>
+  <device>sfd10001</device>
+  <device>sfd1001</device>
+  <device>side116</device>
+  <device>simutrek</device>
+  <device>slutprov</device>
+  <device>sns_dsp1bleg</device>
+  <device>sns_dsp1leg</device>
+  <device>sns_dsp1leg_hi</device>
+  <device>sns_dsp2leg</device>
+  <device>sns_dsp3leg</device>
+  <device>sns_dsp4leg</device>
+  <device>sns_rom_sgb</device>
+  <device>sns_rom_sgb2</device>
+  <device>sns_seta10leg</device>
+  <device>sns_seta11leg</device>
+  <device>spc1000_fdd_exp</device>
+  <device>spectrum_fuller</device>
+  <device>spectrum_intf1</device>
+  <device>spectrum_melodik</device>
+  <device>spectrum_mikroplus</device>
+  <device>spectrum_plus2test</device>
+  <device>spectrum_uslot</device>
+  <device>spectrum_usource</device>
+  <device>spectrum_uspeech</device>
+  <device>ss50_mpc</device>
+  <device>ss50_mps</device>
+  <device>steeltal_board</device>
+  <device>steeltal1_board</device>
+  <device>steeltalp_board</device>
+  <device>stereo_fx</device>
+  <device>stic</device>
+  <device>strtdriv_board</device>
+  <device>stunrun_board</device>
+  <device>sv601</device>
+  <device>sv602</device>
+  <device>sv603</device>
+  <device>sv802</device>
+  <device>sv805</device>
+  <device>sv806</device>
+  <device>sx1541</device>
+  <device>t5182</device>
+  <device>tetriskr_cga</device>
+  <device>tgui9680</device>
+  <device>ti_hx5102</device>
+  <device>ti8x_glinkhle</device>
+  <device>ti8x_tconn</device>
+  <device>ti99_bwg</device>
+  <device>ti99_evpc</device>
+  <device>ti99_fdc</device>
+  <device>ti99_gkracker</device>
+  <device>ti99_hfdc</device>
+  <device>ti99_myarcmem</device>
+  <device>ti99_pcode</device>
+  <device>ti99_rs232</device>
+  <device>ti99_speech</device>
+  <device>tiki100_8088</device>
+  <device>tk02</device>
+  <device>tms32030</device>
+  <device>tms32031</device>
+  <device>tms32032</device>
+  <device>to7_io_line</device>
+  <device>trs80m2kb</device>
+  <device>tvc_hbf</device>
+  <device>uni800</device>
+  <device>unidisk</device>
+  <device>upd7220</device>
+  <device>vic1010</device>
+  <device>vic1011</device>
+  <device>vic1112</device>
+  <device>vic1515</device>
+  <device>vic1520</device>
+  <device>vic20_fe3</device>
+  <device>vic20_videopak</device>
+  <device>victor9k_fdc</device>
+  <device>victor9k_kb</device>
+  <device>victor9kb</device>
+  <device>votrax</device>
+  <device>vp575</device>
+  <device>vp700</device>
+  <device>vrc5074</device>
+  <device>vtech_fdc</device>
+  <device>vtech_printer</device>
+  <device>vtech_rs232</device>
+  <device>vtech_rtty</device>
+  <device>vtech_wordpro</device>
+  <device>vz_rs232</device>
+  <device>vz_rtty</device>
+  <device>wangpc_lic</device>
+  <device>wangpc_rtc</device>
+  <device>wangpc_wdc</device>
+  <device>wangpckb</device>
+  <device>wd1002a_wx1</device>
+  <device>wd1007a</device>
+  <device>wdxt_gen</device>
+  <device>wordpro</device>
+  <device>wyse700</device>
+  <device>x68k_cz6bs1</device>
+  <device>x820kb</device>
+  <device>xtide</device>
+  <device>ym2608</device>
+  <device>z8671</device>
+  <device>zorba_kbd</device>
+</devices>


### PR DESCRIPTION
## Description

Updates MAME resources (names, bioses and devices) to update ES automation for things like Vertical Arcade auto-collection.
These changes were sourced from https://github.com/batocera-linux/batocera-emulationstation so credit to Bato for these updates

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

Built local version of ES and tested it against updated resource XMLs.  The list of vertical arcade games displayed in the auto collection is updated and bringing in additional games now.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code