### PR TITLE
add a Simple HTTP Server toggle

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -3810,6 +3810,21 @@ void GuiMenu::openNetworkSettings_batocera(bool selectWifiEnable, bool selectAdh
                                 SystemConf::getInstance()->saveSystemConf();
                 });
 
+     auto simple_http_enabled = std::make_shared<SwitchComponent>(mWindow);
+                bool simplehttpEnabled = SystemConf::getInstance()->get("simplehttp.enabled") == "1";
+                simple_http_enabled->setState(simplehttpEnabled);
+                s->addWithLabel(_("ENABLE SIMPLE HTTP SERVER"), simple_http_enabled);
+                simple_http_enabled->setOnChangedCallback([simple_http_enabled] {
+                        if(simple_http_enabled->getState() == false) {
+                                runSystemCommand("systemctl disable --now simple-http-server", "", nullptr);
+                        } else {
+                                runSystemCommand("systemctl enable --now simple-http-server", "", nullptr);
+                        }
+                bool simplehttpenabled = simple_http_enabled->getState();
+                SystemConf::getInstance()->set("simplehttp.enabled", simplehttpenabled ? "1" : "0");
+                                SystemConf::getInstance()->saveSystemConf();
+                });
+
 
 	s->addGroup(_("CLOUD SERVICES"));
 


### PR DESCRIPTION
# Simple HTTP Server 

## Description

A compliment commit for https://github.com/JustEnoughLinuxOS/distribution/pull/2566, adding support for Simple HTTP Server

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How Has This Been Tested Locally?

Tested on ODROID GO Ultra (Amlogic S922X)
