### PR TITLE
Update ScreenScraper API URL

### DIFF
--- a/es-app/src/scrapers/ScreenScraper.cpp
+++ b/es-app/src/scrapers/ScreenScraper.cpp
@@ -25,7 +25,7 @@ std::string ScreenScraperRequest::ensureUrl(const std::string url)
 {
 	return Utils::String::replace(
 		Utils::String::replace(url, " ", "%20") ,
-		"#screenscraperserveur#", "https://www.screenscraper.fr/");
+		"#screenscraperserveur#", "https://api.screenscraper.fr/");
 }
 
 /**

--- a/es-app/src/scrapers/ScreenScraper.h
+++ b/es-app/src/scrapers/ScreenScraper.h
@@ -71,7 +71,7 @@ public:
 		std::string getUserInfoUrl() const;
 
 		// Access to the API
-		const std::string API_URL_BASE = "https://www.screenscraper.fr/api2";
+		const std::string API_URL_BASE = "https://api.screenscraper.fr/api2";
 		std::string region = "US";
 
 	} configuration;


### PR DESCRIPTION
ScreenScraper recently asked 3rd party software to move to api.screenscraper.fr instead of www to enables better management of load balancing on their server.

This update makes that change to ES.

Direct from the ScreenScraper discord:
"hello les devs ! il faudrait SVP, dans votre prochaine beta, si possible, passer l'url "www.screenscraper.fr" en "api.screenscraper.fr" afin de pouvoir, de notre coté, gérer le load balancing de l'api indépendamment du celui du site internet et de soulager le serveur principal ! d'avance merci" https://discord.com/channels/472428967928922132/552889606526468106/1194207022204321812

Translation:
hello devs! Please, in your next beta, if possible, change the URL "www.screenscraper.fr" to "api.screenscraper.fr" in order to be able, on our side, to manage the load balancing of the API independently of that of the website and to relieve the main server! thanks in advance

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested Locally?

I built and tested this change in x86_64, added my screescraper credentials and scraped an nes game.   It looks to be working the same as using www

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code